### PR TITLE
feat: support HTML content as alternative to URL for invoice scraping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const app: Express = express();
 const port = process.env.PORT || 8080;
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: "5mb" }));
 app.use(
   pinoHttp({
     logger,
@@ -78,19 +78,25 @@ app.get("/fakeLoad", async (req, res) => {
 
 app.post("/fetchInvoiceData", async (req, res: Response) => {
   try {
-    const { url } = req.body;
+    const { url, html } = req.body;
 
-    logger.info({ url }, "Loading invoice from url");
-
-    if (!url) {
-      throw new ApplicationError("You should provide the invoice url!");
+    if (!url && !html) {
+      throw new ApplicationError(
+        "You should provide the invoice url or html content!"
+      );
     }
 
-    if (!isValidUrl(url)) {
-      throw new ApplicationError("Invalid URL!");
+    if (url) {
+      logger.info({ url }, "Loading invoice from url");
+
+      if (!isValidUrl(url)) {
+        throw new ApplicationError("Invalid URL!");
+      }
+    } else {
+      logger.info("Loading invoice from html content");
     }
 
-    const scraper = new Scraper(url);
+    const scraper = new Scraper({ url, html });
     const data = await scraper.load();
 
     res.send(AppResponse.create(true, data));
@@ -125,7 +131,7 @@ app.post("/load", async (req, res: Response) => {
       throw new ApplicationError("Invalid URL!");
     }
 
-    const scraper = new Scraper(url);
+    const scraper = new Scraper({ url });
     const data = await scraper.load();
 
     const sale = await saleDB.get(data.sale.id);

--- a/src/scraper/index.ts
+++ b/src/scraper/index.ts
@@ -5,11 +5,13 @@ export class Scraper {
   private static instance: Scraper;
 
   protected baseUrl: string;
+  protected htmlContent: string;
   private browser: puppeteer.Browser;
   protected page: puppeteer.Page;
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl;
+  constructor({ url, html }: { url?: string; html?: string }) {
+    this.baseUrl = url;
+    this.htmlContent = html;
   }
 
   launchBrowser = async () => {
@@ -35,9 +37,19 @@ export class Scraper {
     await this.page.goto(url);
   };
 
+  initPageFromHtml = async (html: string) => {
+    await this.launchBrowser();
+    this.page = await this.browser.newPage();
+    await this.page.setContent(html, { waitUntil: "domcontentloaded" });
+  };
+
   load = async () => {
     try {
-      await this.initPage(this.baseUrl);
+      if (this.htmlContent) {
+        await this.initPageFromHtml(this.htmlContent);
+      } else {
+        await this.initPage(this.baseUrl);
+      }
 
       const store = await this.loadStoreInfo();
       const sale = await this.loadSaleInfo();
@@ -104,7 +116,7 @@ export class Scraper {
       return store;
     }, "#conteudo > div.txtCenter");
     if(!store) {
-      throw new ApplicationError("Store not found");
+      throw new ApplicationError("Invoice data could not be extracted from the provided page");
     }
     return store;
   };


### PR DESCRIPTION
Allow the scraper to accept HTML content directly via page.setContent() instead of navigating to a URL. This enables loading invoices from manually saved HTML files when QR codes redirect to reCAPTCHA pages.

- Scraper constructor accepts { url?, html? } instead of a plain string
- New initPageFromHtml() method using page.setContent()
- POST /fetchInvoiceData accepts { html } as alternative to { url }
- Increase express.json body limit to 5mb for large HTML payloads
- Improve error message when invoice data cannot be extracted